### PR TITLE
Add DKK to Currencies

### DIFF
--- a/money/Money/Currency.cs
+++ b/money/Money/Currency.cs
@@ -46,6 +46,12 @@ namespace money
         /// <summary>
         /// NZD
         /// </summary>
-        NZD = 554
+        NZD = 554,
+
+        /// <summary>
+        /// DKK
+        /// </summary>
+        DKK = 208
+
     }
 }

--- a/money/Money/CurrencyInfo.Entries.cs
+++ b/money/Money/CurrencyInfo.Entries.cs
@@ -78,6 +78,14 @@ namespace money
                         Code = Currency.INR
                     }
                 },
+            {
+                Currency.DKK,
+                new CurrencyInfo
+                    {
+                        DisplayName = "Danish Krone",
+                        Code = Currency.DKK
+                    }
+                }
         };
     }
 }


### PR DESCRIPTION
When I ran the Money.Tests on my machine I had 27 failures because my Region is DK. Adding the DKK to Currencies so it can be used in Denmark.